### PR TITLE
Use invokable commands - sql:dump

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -1,7 +1,4 @@
 {
   "patches": {
-    "symfony/console": {
-      "[Console] Add getter for the original command code object (https://github.com/symfony/symfony/pull/61078)": "./patches/console.getcode.diff"
-    }
   }
 }

--- a/docs/install.md
+++ b/docs/install.md
@@ -13,7 +13,7 @@
 !!! note
     - See [Usage](usage.md) for details on using Drush. 
     - To use a non-default PHP, [edit ~/.bashrc so that the desired PHP is in front of your $PATH](http://stackoverflow.com/questions/4145667/how-to-override-the-path-of-php-to-use-the-mamp-path/10653443#10653443). If that is not desirable, you can change your PATH for just one request: `PATH=/path/to/php:$PATH` drush status ...`
-    - To use a custom php.ini for Drush requests, [see this comment](https://github.com/drush-ops/drush/issues/3294#issuecomment-370201342). 
+    - To use custom PHP configuration such as _memory_limit_, create a custom php.ini for Drush requests as per https://github.com/drush-ops/drush/issues/3294#issuecomment-370201342 and https://github.com/drush-ops/drush/issues/3294#issuecomment-618962852. This approach ensures that the custom config is used for the subprocesses as well (e.g. `updatedb`).   
     - See our [guide on porting commandfiles](https://weitzman.github.io/blog/port-to-drush9) from Drush 8 to later versions. Also note that alias and config files use a new .yml format in Drush 10+.
 
 Drupal Compatibility

--- a/docs/install.md
+++ b/docs/install.md
@@ -38,7 +38,7 @@ Drupal Compatibility
     <td> 8.1+ </td>
     <!-- Released Jun 2023 -->
     <td> TBD </td>
-    <td></td> <td></td> <td></td> <td><b>✅</b></td> <td></td>
+    <td></td> <td></td> <td></td> <td><b>✓</b></td> <td></td>
   </tr>
   <tr>
     <td> Drush 11 </td>

--- a/src/Application.php
+++ b/src/Application.php
@@ -346,7 +346,7 @@ class Application extends SymfonyApplication implements LoggerAwareInterface, Co
         $this->doRenderThrowable($e, $output);
     }
 
-    // Discover event listeners, and add those that do not require bootstrap.
+    // Discover event listeners and add those that do not require bootstrap.
     protected function addListeners($commandfileSearchpath): void
     {
         $listenerClasses = $this->serviceManager->discoverListeners($commandfileSearchpath, '\Drush');

--- a/src/Attributes/Bootstrap.php
+++ b/src/Attributes/Bootstrap.php
@@ -15,7 +15,7 @@ class Bootstrap
     /**
      * @param $level
      *   The level to bootstrap to.
-     * @package $extra
+     * @param int|null $max_level
      *   A maximum level when used with MAX.
      */
     public function __construct(

--- a/src/Attributes/Bootstrap.php
+++ b/src/Attributes/Bootstrap.php
@@ -7,7 +7,6 @@ namespace Drush\Attributes;
 use Attribute;
 use Consolidation\AnnotatedCommand\Parser\CommandInfo;
 use Drush\Boot\DrupalBootLevels;
-use Exception;
 use JetBrains\PhpStorm\ExpectedValues;
 
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]

--- a/src/Attributes/Bootstrap.php
+++ b/src/Attributes/Bootstrap.php
@@ -7,6 +7,7 @@ namespace Drush\Attributes;
 use Attribute;
 use Consolidation\AnnotatedCommand\Parser\CommandInfo;
 use Drush\Boot\DrupalBootLevels;
+use Exception;
 use JetBrains\PhpStorm\ExpectedValues;
 
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]

--- a/src/Attributes/FieldLabels.php
+++ b/src/Attributes/FieldLabels.php
@@ -5,10 +5,20 @@ declare(strict_types=1);
 namespace Drush\Attributes;
 
 use Attribute;
+use Consolidation\OutputFormatters\Options\FormatterOptions;
+use Drush\Formatters\FormatterConfigurationItemProviderInterface;
 use JetBrains\PhpStorm\Deprecated;
 
-#[Deprecated(replacement: 'Call \Drush\Formatters\FormatterTrait::configureFormatter during configure()')]
-#[Attribute(Attribute::TARGET_METHOD)]
-class FieldLabels extends \Consolidation\AnnotatedCommand\Attributes\FieldLabels
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
+class FieldLabels extends \Consolidation\AnnotatedCommand\Attributes\FieldLabels implements FormatterConfigurationItemProviderInterface
 {
+
+    const KEY = FormatterOptions::FIELD_LABELS;
+
+    public function getConfigurationItem(\ReflectionAttribute $attribute): array
+    {
+        $args = $attribute->getArguments();
+        return [self::KEY => $args['labels']];
+    }
+
 }

--- a/src/Attributes/Formatter.php
+++ b/src/Attributes/Formatter.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drush\Attributes;
+
+use Attribute;
+use Consolidation\AnnotatedCommand\Parser\CommandInfo;
+use Drush\Commands\DrushCommands;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Formatter
+{
+    /**
+     * @param string $returnType
+     *     The command's return type, before formatting.
+     * @param ?string $defaultFormatter
+     *    The fallback formatter.
+     */
+    public function __construct(
+        public string $returnType,
+        public ?string $defaultFormatter = 'table',
+    ) {
+    }
+}

--- a/src/Attributes/OptionsetTableSelection.php
+++ b/src/Attributes/OptionsetTableSelection.php
@@ -9,8 +9,8 @@ use Consolidation\AnnotatedCommand\Parser\CommandInfo;
 use Drush\Commands\DrushCommands;
 use JetBrains\PhpStorm\Deprecated;
 
-#[Deprecated(replacement: 'Call \Drush\Commands\OptionSets::tableSelection during configure()')]
-#[Attribute(Attribute::TARGET_METHOD)]
+// #[Deprecated(replacement: 'Call \Drush\Commands\OptionSets::tableSelection during configure()')]
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
 class OptionsetTableSelection
 {
     public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)

--- a/src/Commands/config/ConfigCommands.php
+++ b/src/Commands/config/ConfigCommands.php
@@ -28,6 +28,7 @@ use Drush\Exec\ExecTrait;
 use Drush\Utils\FsUtils;
 use Drush\Utils\StringUtils;
 use JetBrains\PhpStorm\Deprecated;
+use RuntimeException;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Helper\Table;
@@ -523,7 +524,7 @@ final class ConfigCommands extends DrushCommands implements StdinAwareInterface
 
         $prefix = ['diff'];
         if (self::programExists('git')) {
-            $prefix = ['git', 'diff'];
+            $prefix = ['git', 'diff', '--no-index', '--exit-code'];
             if ($output->isDecorated()) {
                 $prefix[] = '--color=always';
             }
@@ -531,6 +532,10 @@ final class ConfigCommands extends DrushCommands implements StdinAwareInterface
         $args = array_merge($prefix, ['-u', $temp_destination_dir, $temp_source_dir]);
         $process = Drush::process($args);
         $process->run();
+        // An exit code of 1 merely indicates that there is a diff.
+        if ($process->getExitCode() >= 2) {
+            throw new RuntimeException($process->getExitCodeText());
+        }
         return $process->getOutput();
     }
 }

--- a/src/Commands/core/DrupalCommands.php
+++ b/src/Commands/core/DrupalCommands.php
@@ -87,8 +87,11 @@ final class DrupalCommands extends DrushCommands
 
         drupal_load_updates();
 
-        $requirements = $this->getModuleHandler()->invokeAll('requirements', ['runtime']);
-        $this->getModuleHandler()->alter('requirements', $requirements);
+        $requirements = $this->moduleHandler->invokeAll('requirements', ['runtime']);
+        $runtime_requirements = $this->moduleHandler->invokeAll('runtime_requirements');
+        $requirements = array_merge($requirements, $runtime_requirements);
+        $this->moduleHandler->alter('requirements', $requirements);
+        $this->moduleHandler->alter('runtime_requirements', $requirements);
         // If a module uses "$requirements[] = " instead of
         // "$requirements['label'] = ", then build a label from
         // the title.

--- a/src/Commands/core/EntityCommands.php
+++ b/src/Commands/core/EntityCommands.php
@@ -20,6 +20,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drush\Attributes as CLI;
 use Drush\Commands\AutowireTrait;
 use Drush\Commands\DrushCommands;
+use Drush\Exceptions\UserAbortException;
 use Drush\Utils\StringUtils;
 
 final class EntityCommands extends DrushCommands implements StdinAwareInterface
@@ -70,6 +71,12 @@ final class EntityCommands extends DrushCommands implements StdinAwareInterface
         if (empty($result)) {
             $this->logger()->success(dt('No matching entities found.'));
         } else {
+            if (empty($options['limit']) && empty($ids)) {
+                if (!$this->io()->confirm(dt('You are about to delete !count entities. Do you wish to continue?', ['!count' => count($result)]), false)) {
+                    throw new UserAbortException();
+                }
+            }
+
             $chunks = array_chunk($result, (int)$options['chunks'], true);
             $progress = $this->io()->progress('Deleting entities', count($chunks));
             $progress->start();

--- a/src/Commands/core/TwigCommands.php
+++ b/src/Commands/core/TwigCommands.php
@@ -16,6 +16,9 @@ use Drush\Drush;
 use Drush\Utils\StringUtils;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
+use Twig\Error\LoaderError;
+use Twig\Error\RuntimeError;
+use Twig\Error\SyntaxError;
 
 final class TwigCommands extends DrushCommands
 {
@@ -103,7 +106,12 @@ final class TwigCommands extends DrushCommands
         foreach ($files as $file) {
             $relative = Path::makeRelative($file->getRealPath(), Drush::bootstrapManager()->getRoot());
             // Loading the template ensures the compiled template is cached.
-            $this->twig->load($relative);
+            try {
+                $this->twig->load($relative);
+            } catch (LoaderError | RuntimeError | SyntaxError $e) {
+                $this->logger()->error($e->getMessage());
+                continue;
+            }
             $this->logger()->success(dt('Compiled twig template !path', ['!path' => $relative]));
         }
     }

--- a/src/Commands/core/UserCommands.php
+++ b/src/Commands/core/UserCommands.php
@@ -215,6 +215,7 @@ final class UserCommands extends DrushCommands
     #[CLI\DefaultTableFields(fields: self::INF_DEFAULT_FIELDS)]
     #[CLI\FilterDefaultField(field: 'name')]
     #[CLI\Usage(name: "drush user:create newuser --mail='person@example.com' --password='letmein'", description: 'Create a new user account with the name newuser, the email address person@example.com, and the password letmein')]
+    #[CLI\Usage(name: "drush user:create anotheruser --fields=uuid,langcode", description: 'Create a new user account with the name anotheruser and show the values of the UUID and Language fields')]
     public function createUser(string $name, $options = ['format' => 'table', 'password' => self::REQ, 'mail' => self::REQ]): RowsOfFields|CommandError
     {
         $new_user = [

--- a/src/Commands/sql/SqlDumpCommand.php
+++ b/src/Commands/sql/SqlDumpCommand.php
@@ -5,28 +5,33 @@ declare(strict_types=1);
 namespace Drush\Commands\sql;
 
 use Consolidation\OutputFormatters\FormatterManager;
-use Consolidation\OutputFormatters\Options\FormatterOptions;
 use Consolidation\OutputFormatters\StructuredData\PropertyList;
 use Drush\Attributes as CLI;
+use Drush\Boot\BootstrapManager;
 use Drush\Boot\DrupalBootLevels;
 use Drush\Commands\AutowireTrait;
-use Drush\Commands\OptionSets;
 use Drush\Formatters\FormatterTrait;
 use Drush\Sql\SqlBase;
 use Drush\Style\DrushStyle;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
     name: self::NAME,
     description: 'Export the Drupal DB as SQL using mysqldump or equivalent.',
-    aliases: ['sql-dump']
+    usages: ['sql:dump --result-file=../18.sql', 'sql:dump --skip-tables-key=common', 'sql:dump --extra-dump=--no-data'],
+    // @todo alias causes problem with command name https://github.com/symfony/symfony/pull/61367
+    // aliases: ['sql-dump']
 )]
-#[CLI\Bootstrap(level: DrupalBootLevels::MAX, max_level: DrupalBootLevels::CONFIGURATION)]
-final class SqlDumpCommand extends Command
+#[CLI\FieldLabels(labels: ['path' => 'Path'])]
+#[CLI\Formatter(returnType: PropertyList::class, defaultFormatter: 'null')]
+#[CLI\OptionsetSql]
+#[CLI\OptionsetTableSelection]
+#[CLI\Bootstrap(level: DrupalBootLevels::NONE)]
+final class SqlDumpCommand
 {
     use AutowireTrait;
     use FormatterTrait;
@@ -34,37 +39,34 @@ final class SqlDumpCommand extends Command
     public const NAME = 'sql:dump';
 
     public function __construct(
-        protected readonly FormatterManager $formatterManager
-    ) {
-        parent::__construct();
-    }
+        protected BootstrapManager $bootstrapManager,
+        protected readonly FormatterManager $formatterManager,
+    ) {}
 
-    protected function configure()
+    public function __invoke(
+        InputInterface $input,
+        OutputInterface $output,
+        #[Option(name: 'result-file', description: 'Save to a file. The file should be relative to Drupal root. If --result-file is provided with the value \'auto\', a date-based filename will be created under ~/drush-backups directory.')]
+        ?string $resultFile = null,
+        // create-db is used by sql:sync, since including the DROP TABLE statements interferes with the import when the database is created.
+        #[Option(name: 'create-db', description: 'Omit DROP TABLE statements. Used by Postgres and Oracle only.')]
+        bool $createDb = false,
+        #[Option(name: 'data-only', description: 'Dump data without statements to create any of the schema.')]
+        bool $dataOnly = false,
+        #[Option(name: 'ordered-dump', description: 'Order by primary key and add line breaks for efficient diffs. Slows down the dump. Mysql only.')]
+        bool $orderedDump = false,
+        #[Option(name: 'gzip', description: 'Compress the dump using the gzip program which must be in your <info>$PATH</info>.')]
+        bool $gzip = false,
+        #[Option(name: 'extra', description: 'Add custom arguments/options when connecting to database (used internally to list tables).')]
+        ?string $extra = null,
+        #[Option(name: 'extra-dump', description: 'Add custom arguments/options to the dumping of the database (e.g. <info>mysqldump</info> command).')]
+        ?string $extraDump = null,
+    ): int
     {
-        $this
-            ->addOption('result-file', null, InputOption::VALUE_REQUIRED, 'Save to a file. The file should be relative to Drupal root. If --result-file is provided with the value \'auto\', a date-based filename will be created under ~/drush-backups directory.')
-            // create-db is used by sql:sync, since including the DROP TABLE statements interferes with the import when the database is created.
-            ->addOption('create-db', null, InputOption::VALUE_NONE, 'Omit DROP TABLE statements. Used by Postgres and Oracle only.')
-            ->addOption('data-only', null, InputOption::VALUE_NONE, 'Dump data without statements to create any of the schema.')
-            ->addOption('ordered-dump', null, InputOption::VALUE_NONE, 'Order by primary key and add line breaks for efficient diffs. Slows down the dump. Mysql only.')
-            ->addOption('gzip', null, InputOption::VALUE_NONE, 'Compress the dump using the gzip program which must be in your <info>$PATH</info>.')
-            ->addOption('extra', null, InputOption::VALUE_REQUIRED, 'Add custom arguments/options when connecting to database (used internally to list tables).')
-            ->addOption('extra-dump', null, InputOption::VALUE_REQUIRED, 'Add custom arguments/options to the dumping of the database (e.g. <info>mysqldump</info> command).')
-            ->addUsage('sql:dump --result-file=../18.sql')
-            ->addUsage('sql:dump --skip-tables-key=common')
-            ->addUsage('sql:dump --extra-dump=--no-data');
-        $formatterOptions = (new FormatterOptions())
-            ->setFieldLabels(['path' => 'Path']);
-        $this->configureFormatter(PropertyList::class, $formatterOptions);
-        OptionSets::sql($this);
-        OptionSets::tableSelection($this);
-    }
-
-    public function execute(InputInterface $input, OutputInterface $output): int
-    {
+        $this->bootstrapManager->bootstrapMax(DrupalBootLevels::CONFIGURATION);
         $data = $this->doExecute($input, $output);
         $this->writeFormattedOutput($input, $output, $data);
-        return self::SUCCESS;
+        return Command::SUCCESS;
     }
 
     protected function doExecute(InputInterface $input, OutputInterface $output): PropertyList

--- a/src/Formatters/FormatterConfigurationItemProviderInterface.php
+++ b/src/Formatters/FormatterConfigurationItemProviderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Drush\Formatters;
+
+interface FormatterConfigurationItemProviderInterface
+{
+    const KEY = '';
+
+    public function getConfigurationItem(\ReflectionAttribute $attribute): array;
+}

--- a/src/Listeners/FormatterListener.php
+++ b/src/Listeners/FormatterListener.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drush\Listeners;
+
+use Consolidation\OutputFormatters\FormatterManager;
+use Consolidation\OutputFormatters\Options\FormatterOptions;
+use Drush\Attributes as CLI;
+use Drush\Boot\DrupalBootLevels;
+use Drush\Commands\AutowireTrait;
+use Drush\Event\ConsoleDefinitionsEvent;
+use Drush\Formatters\FormatterConfigurationItemProviderInterface;
+use ReflectionObject;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+#[AsEventListener]
+#[CLI\Bootstrap(level: DrupalBootLevels::NONE)]
+final class FormatterListener {
+    use AutowireTrait;
+
+    public function __construct(
+        protected FormatterManager $formatterManager,
+    ) {
+    }
+
+    public function __invoke(ConsoleDefinitionsEvent $event): void
+    {
+        foreach ($event->getApplication()->all() as $id => $command) {
+            $code = $command->getCode() ?? $command;
+            $reflectionObject = new \ReflectionObject($code);
+            if (!$attributes = $reflectionObject->getAttributes(CLI\Formatter::class)) {
+                continue;
+            }
+            /** @var \Drush\Attributes\Formatter $attribute */
+            $attribute = $attributes[0]->newInstance();
+            $configurationData = $this->getConfigurationData($reflectionObject);
+            $formatterOptions = new FormatterOptions($configurationData, []);
+            $code->setFormatterOptions($formatterOptions);
+
+            $inputOptions = $this->formatterManager->automaticOptions($formatterOptions, $attribute->returnType);
+            foreach ($inputOptions as $inputOption) {
+                if ($command->getDefinition()->hasOption($inputOption->getName())) {
+                    // This Listener also fires during full bootstrap, so skip if already present.
+                    continue;
+                }
+                $mode = $this->getPrivatePropValue($inputOption, 'mode');
+                $suggestedValues = $this->getPrivatePropValue($inputOption, 'suggestedValues');
+                $command->addOption($inputOption->getName(), $inputOption->getShortcut(), $mode, $inputOption->getDescription(), $inputOption->getDefault(), $suggestedValues);
+            }
+            // Use the command's fallback for --format.
+            $command->getDefinition()->getOption('format')->setDefault($attribute->defaultFormatter);
+
+            // @todo Move to own listener.
+            // Add the --filter option if the command has a FilterDefaultField attribute.
+            $attributes = $reflectionObject->getAttributes(CLI\FilterDefaultField::class);
+            if (!empty($attributes)) {
+                $instance = $attributes[0]->newInstance();
+                $command->addOption('filter', null, InputOption::VALUE_REQUIRED, 'Filter output based on provided expression. Default field: ' . $instance->field);
+            }
+        }
+    }
+
+    /**
+     * Build the formatter configuration from the command's attributes
+     */
+    protected function getConfigurationData(ReflectionObject $reflection): array
+    {
+        $configurationData = [];
+        $attributes = $reflection->getAttributes();
+        foreach ($attributes as $attribute) {
+            $instance = $attribute->newInstance();
+            if ($instance instanceof FormatterConfigurationItemProviderInterface) {
+                $configurationData = array_merge($configurationData, $instance->getConfigurationItem($attribute));
+            }
+        }
+        return $configurationData;
+    }
+
+    protected function getPrivatePropValue(mixed $object, $name): mixed
+    {
+        $rc = new \ReflectionClass($object);
+        $prop = $rc->getProperty($name);
+        return $prop->getValue($object);
+    }
+}

--- a/src/Listeners/OptionsetSqlListener.php
+++ b/src/Listeners/OptionsetSqlListener.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drush\Listeners;
+
+use Drush\Attributes as CLI;
+use Drush\Boot\DrupalBootLevels;
+use Drush\Event\ConsoleDefinitionsEvent;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+#[AsEventListener]
+#[CLI\Bootstrap(level: DrupalBootLevels::NONE)]
+class OptionsetSqlListener
+{
+    public function __invoke(ConsoleDefinitionsEvent $event): void
+    {
+        foreach ($event->getApplication()->all() as $id => $command) {
+            $reflection = new \ReflectionObject($command->getCode() ?? $command);
+            $attributes = $reflection->getAttributes(CLI\OptionsetSql::class);
+            if (empty($attributes)) {
+                continue;
+            }
+            $command->addOption('database', '', InputOption::VALUE_REQUIRED, 'The DB connection key if using multiple connections in settings.php.', 'default');
+            $command->addOption('db-url', '', InputOption::VALUE_REQUIRED, 'A Drupal 6 style database URL. For example <info>mysql://root:pass@localhost:port/dbname</info>');
+            $command->addOption('target', '', InputOption::VALUE_REQUIRED, 'The name of a target within the specified database connection.', 'default');
+            $command->addOption('show-passwords', '', InputOption::VALUE_NONE, 'Show password on the CLI. Useful for debugging.');
+        }
+    }
+}

--- a/src/Listeners/OptionsetTableSelectionListener.php
+++ b/src/Listeners/OptionsetTableSelectionListener.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drush\Listeners;
+
+use Drush\Attributes as CLI;
+use Drush\Attributes\OptionsetTableSelection;
+use Drush\Boot\DrupalBootLevels;
+use Drush\Event\ConsoleDefinitionsEvent;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+#[AsEventListener]
+#[CLI\Bootstrap(level: DrupalBootLevels::NONE)]
+class OptionsetTableSelectionListener
+{
+    public function __invoke(ConsoleDefinitionsEvent $event): void
+    {
+        foreach ($event->getApplication()->all() as $id => $command) {
+            $reflection = new \ReflectionObject($command->getCode() ?? $command);
+            $attributes = $reflection->getAttributes(OptionsetTableSelection::class);
+            if (empty($attributes)) {
+                continue;
+            }
+            $command->addOption('skip-tables-key', '', InputOption::VALUE_REQUIRED, 'A key in the $skip_tables array. @see [Site aliases](../site-aliases.md)');
+            $command->addOption('structure-tables-key', '', InputOption::VALUE_REQUIRED, 'A key in the $structure_tables array. @see [Site aliases](../site-aliases.md)');
+            $command->addOption('tables-key', '', InputOption::VALUE_REQUIRED, 'A key in the $tables array.');
+            $command->addOption('skip-tables-list', '', InputOption::VALUE_REQUIRED, 'A comma-separated list of tables to exclude completely.');
+            $command->addOption('structure-tables-list', '', InputOption::VALUE_REQUIRED, 'A comma-separated list of tables to include for structure, but not data.');
+            $command->addOption('tables-list', '', InputOption::VALUE_REQUIRED, 'A comma-separated list of tables to transfer.', []);
+        }
+    }
+}

--- a/src/Runtime/ServiceManager.php
+++ b/src/Runtime/ServiceManager.php
@@ -428,24 +428,7 @@ class ServiceManager
         $return = [];
 
         foreach ($callables as $callable) {
-            if (!is_callable($callable)) {
-                $return[] = $callable;
-                continue;
-            }
-
-            // Simplify when https://github.com/symfony/symfony/pull/60394 is merged.
-            /** @var AsCommand $attribute */
-            $attribute = ((new \ReflectionObject($callable))->getAttributes(AsCommand::class)[0] ?? null)?->newInstance()
-                ?? throw new LogicException(\sprintf('The command must use the "%s" attribute.', AsCommand::class));
-
-            $aliases = explode('|', $attribute->name);
-            $name = array_shift($aliases);
-            $command = (new Command($name))
-                ->setAliases($aliases)
-                ->setDescription($attribute->description ?? '')
-                ->setHelp($attribute->help ?? '')
-                ->setCode($callable);
-            $return[] = $command;
+            $return[] = is_callable($callable) ? new Command(null, $callable) : $callable;
         }
 
         return $return;

--- a/sut/drush/Commands/UnitReturnOptionsCommand.php
+++ b/sut/drush/Commands/UnitReturnOptionsCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drush\Commands;
 
+use Drush\Attributes as CLI;
 use Symfony\Component\Console\Attribute\Argument;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -13,15 +14,17 @@ use Symfony\Component\Console\Command\Command;
     description: 'Works like php-eval. Used for testing $command_specific context.',
     // @todo needs bug fix that will be in Console 7.4+
     // hidden: true,
-    aliases: ['unit-eval'],
+    // bug somewhere. alias is becoming part of the command name in the Application
+    // aliases: ['unit-roc'],
 )]
+#[CLI\OptionsetTableSelection]
 final class UnitReturnOptionsCommand
 {
-    public const NAME = 'unit:eval';
+    public const NAME = 'unit:roc';
 
     public function __invoke(
         #[Argument(description: 'Code you wish to run')] string $code,
-    )
+    ): int
     {
         // @todo deal with formatters.
         eval($code . ';');

--- a/tests/integration/MigrateRunnerTest.php
+++ b/tests/integration/MigrateRunnerTest.php
@@ -500,7 +500,7 @@ class MigrateRunnerTest extends UnishIntegrationTestCase
     protected function tearDown(): void
     {
         // Cleanup any created content.
-        $this->drush('entity:delete', ['node']);
+        $this->drush('entity:delete', ['node'], ['yes' => null]);
 
         // Uninstalling Migrate module doesn't automatically drop the tables.
         // @see https://www.drupal.org/project/drupal/issues/2713327


### PR DESCRIPTION
An experiment that extends #6135 by moving sql:dump to be an invokable command. 

- sql:dump no longer extends any class - its its own thing.
- we go back to using attributes for formatter instructions like field names
- we go back to using attributes for optionsets and validators
- commands that use interact() still need to extend Command class
